### PR TITLE
Add support for Roaring Bitmaps. Gives a huge speedup.

### DIFF
--- a/minrx.cpp
+++ b/minrx.cpp
@@ -44,7 +44,6 @@
 #include <string>
 #include <tuple>
 #include <vector>
-#define ROARING	1
 #ifdef CHARSET
 #include <memory>
 #include "charset.h"
@@ -495,8 +494,7 @@ struct CSet {
 				charset_add_cclass(charset, "lower");	// FIXME: Add error checking
 		}
 		return result == CSET_SUCCESS;
-#else
-		// This code should work for ROARING and Mike's original CSet implementation
+#else // both ROARING as well as original CSet
 		auto wct = std::wctype(name.c_str());
 		if (wct) {
 			std::string key = name + ":" + std::setlocale(LC_CTYPE, NULL) + ":" + ((flags & MINRX_REG_ICASE) != 0 ? "1" : "0");
@@ -599,10 +597,7 @@ struct CSet {
 					wc = wconv.nextchr().look();
 					if (wc != L'=' || (wc = wconv.nextchr().look() != L']'))
 						return MINRX_REG_ECOLLATE;
-#elif defined(ROARING)
-					// FIXME: recognize some equivalence classes.
-					return MINRX_REG_ECOLLATE;
-#else
+#else // both ROARING as well as original CSet
 					// FIXME: recognize some equivalence classes.
 					return MINRX_REG_ECOLLATE;
 #endif

--- a/minrx.cpp
+++ b/minrx.cpp
@@ -44,9 +44,12 @@
 #include <string>
 #include <tuple>
 #include <vector>
+#define ROARING	1
 #ifdef CHARSET
 #include <memory>
 #include "charset.h"
+#elif defined(ROARING)
+#include "roaring.h"
 #endif
 #include "minrx.h"
 
@@ -390,6 +393,22 @@ struct CSet {
 	CSet(CSet &&cs): charset(cs.charset) { cs.charset = nullptr; }
 	CSet &operator=(CSet &&cs) { charset = cs.charset; cs.charset = nullptr; return *this; }
 	~CSet() { if (charset) { charset_free(charset); charset = nullptr; } }
+#elif defined(ROARING)
+	static std::map<std::string, CSet> cclmemo;
+	static std::mutex cclmutex;
+	roaring_bitmap_t *bitmap = nullptr;
+	CSet() {
+		bitmap = roaring_bitmap_create();
+	}
+	CSet &operator=(const CSet &) = delete;
+	CSet(CSet &&cs): bitmap(cs.bitmap) { cs.bitmap = nullptr; }
+	CSet(const CSet &cs): bitmap(roaring_bitmap_copy(cs.bitmap)) { } // copy constructor
+	CSet &operator=(CSet &&cs) { bitmap = cs.bitmap; cs.bitmap = nullptr; return *this; }
+	~CSet() { if (bitmap) { roaring_bitmap_free(bitmap); bitmap = nullptr; } }
+	CSet &operator|=(const CSet &cs) {
+		roaring_bitmap_or_inplace(bitmap, cs.bitmap);
+		return *this;
+	}
 #else
 	static std::map<std::string, CSet> cclmemo;
 	static std::mutex cclmutex;
@@ -411,6 +430,10 @@ struct CSet {
 	CSet &invert() {
 #ifdef CHARSET
 		charset_invert(charset); // FIXME: no error checking
+#elif defined(ROARING)
+		roaring_bitmap_t *inverted = roaring_bitmap_flip_closed(bitmap, 0, WCharMax);
+		roaring_bitmap_free(bitmap);
+		bitmap = inverted;
 #else
 		inverted = true;
 #endif
@@ -419,6 +442,8 @@ struct CSet {
 	CSet &set(WChar wclo, WChar wchi) {
 #ifdef CHARSET
 		charset_add_range(charset, wclo, wchi);	// FIXME: no error checking
+#elif defined(ROARING)
+		roaring_bitmap_add_range_closed(bitmap, wclo, wchi);
 #else
 		auto e = Range(wclo - (wclo != std::numeric_limits<WChar>::min()), wchi + (wchi != std::numeric_limits<WChar>::max()));
 		auto [x, y] = ranges.equal_range(e);
@@ -441,6 +466,9 @@ struct CSet {
 #ifdef CHARSET
 		charset_add_char(charset, wc);	// FIXME: no error checking
 		return *this;
+#elif defined(ROARING)
+		roaring_bitmap_add(bitmap, wc);
+		return *this;
 #else
 		return set(wc, wc);
 #endif
@@ -448,6 +476,8 @@ struct CSet {
 	bool test(WChar wc) const {
 #ifdef CHARSET
 		return charset_in_set(charset, wc);
+#elif defined(ROARING)
+		return roaring_bitmap_contains(bitmap, wc);
 #else
 		if (wc < 0)
 			return false;
@@ -466,6 +496,7 @@ struct CSet {
 		}
 		return result == CSET_SUCCESS;
 #else
+		// This code should work for ROARING and Mike's original CSet implementation
 		auto wct = std::wctype(name.c_str());
 		if (wct) {
 			std::string key = name + ":" + std::setlocale(LC_CTYPE, NULL) + ":" + ((flags & MINRX_REG_ICASE) != 0 ? "1" : "0");
@@ -568,6 +599,9 @@ struct CSet {
 					wc = wconv.nextchr().look();
 					if (wc != L'=' || (wc = wconv.nextchr().look() != L']'))
 						return MINRX_REG_ECOLLATE;
+#elif defined(ROARING)
+					// FIXME: recognize some equivalence classes.
+					return MINRX_REG_ECOLLATE;
 #else
 					// FIXME: recognize some equivalence classes.
 					return MINRX_REG_ECOLLATE;


### PR DESCRIPTION
This PR uses [Roaring Bitmaps](https://github.com/RoaringBitmap/CRoaring) to implement character sets (`struct CSet`). It yields a very large speedup.

Note that the instructions currently in Roaring `README.md` for downloading amalgamated C and header files point to an older release. Use the current release in the `wget` commands to retrieve the files.