### PR TITLE
Use a more portable check for UTF-8.

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,9 +71,11 @@ with just two caveats that I'm aware of:
   would be needed to implement this syntax.
 
 * The `[= =]` syntax inside bracket expressions for "collating element
-  equivalence classes" is *entirely* unimplemented.  Again, as far
-  as I know there is no portable POSIX API that gives access to access
-  to the necessary locale information.
+  equivalence classes" uses a semi-portable but horrendously slow and
+  non-standard-conforming algorithm for finding equivalent characters.
+  Each `[= =]` in a pattern likely requires several milliseconds to
+  compile on a modern CPU.  Again, there is no portable POSIX API that
+  offers efficient access to the necessary locale information.
 
 MinRX also provides a few BSD extensions (`\< \>`) and GNU extensions
 (<code>\\\` \\' \b \B \s \S \w \W</code>) that can be optionally enabled

--- a/minrx.3
+++ b/minrx.3
@@ -92,6 +92,22 @@ between compilation and execution.
 This will produce sensible results only in \f(CWLC_CTYPE\fP locales
 that have the same encodings as ASCII/ISO8859 for the regular expression
 special characters.
+.TP
+\f(CWMINRX_REG_MINDISABLE\fP
+Disable POSIX 2024 minimal repetitions.
+.IP
+This option potentially enables better backwards compatibility
+with undefined behavior as implemented by certain widely-used
+pre-POSIX 2024 matchers.
+.IP
+In principle this flag is logically unnecessary, since all
+previous editions of the POSIX standard have stated that
+multiple adjacent repetition operators produce undefined results.
+POSIX 2024 added minimal repetitions by giving a new meaning to
+(only) this formerly-undefined syntax.  No regular expression
+that relies solely on defined behavior of earlier POSIX
+standards will have its meaning changed by the addition of
+minimal repetitions in POSIX 2024.
 .RE
 .PP
 The following values may be returned from

--- a/minrx.cpp
+++ b/minrx.cpp
@@ -267,7 +267,7 @@ struct QVec {
 	}
 	bool contains(UINT k) const { return qset.contains(k); }
 	bool empty() const { return qset.empty(); }
-	std::tuple<bool, DATA&> insert(UINT k, const DATA& v) {
+	std::tuple<bool, DATA&> insert(UINT k, const DATA&) {
 		bool newly = qset.insert(k);
 		// WARNING: if newly inserted then we are returning a reference to uninitialized memory
 		// and it is the caller's responsibility to construct valid DATA there.
@@ -303,7 +303,7 @@ public:
 	WConv(Encoding e, const char *bp): WConv(e, bp, bp + std::strlen(bp)) { }
 	auto lookahead() const { return WConv(*this).nextchr(); }
 	WChar nextchr() { return (this->*nextfn)(); }
-	WChar nextbyte() { return cp != ep ? (unsigned char) *cp++ : End; }
+	WChar nextbyte() { return cp != ep ? (unsigned char) *cp++ : (WChar) End; }
 	WChar nextmbtowc() {
 		wchar_t wct = L'\0';
 		if (cp != ep) {

--- a/minrx.cpp
+++ b/minrx.cpp
@@ -807,10 +807,10 @@ struct Compile {
 	Subexp mkrep(const Subexp &lh, bool optional, bool infinite, NInt nstk) {
 		auto [lhs, lhmaxstk, _] = lh;
 		if (optional && !infinite) {
-			for (auto &l : lhs) l.nstk += 1;
+			for (auto &l : lhs) l.nstk += 2;
 			auto lhsize = lhs.size();
-			lhs.push_front({Node::Skip, {lhsize, 0}, nstk + 1});
-			return {lhs, lhmaxstk + 1, MINRX_REG_SUCCESS};
+			lhs.push_front({Node::Skip, {lhsize, 0}, nstk + 2});
+			return {lhs, lhmaxstk + 2, MINRX_REG_SUCCESS};
 		} else {
 			for (auto &l : lhs) l.nstk += 3;
 			auto lhsize = lhs.size();
@@ -841,9 +841,9 @@ struct Compile {
 			lhmaxstk += 1;
 			rhmaxstk += 1;
 			for (auto &r : rhs)
-				r.nstk += 1;
+				r.nstk += 2;
 			auto rhsize = rhs.size();
-			rhs.push_front({Node::Skip, {rhsize, 0}, nstk + 1});
+			rhs.push_front({Node::Skip, {rhsize, 1}, nstk + 2});
 			for (; k < n; ++k)
 				lhs.insert(lhs.end(), rhs.begin(), rhs.end());
 		}
@@ -1250,8 +1250,8 @@ struct Execute {
 					add(ncsv, k - n.args[0], nstk + 3, ns, wcnext, ns.substack.get(nstk), ns.substack.get(nstk + 1) - 1, (NInt) off);
 				break;
 			case Node::Skip:
-				add(ncsv, k + 1, nstk, ns, wcnext, (NInt) 0);
-				add(ncsv, k + 1 + n.args[0], nstk, ns, wcnext, (NInt) 1);
+				add(ncsv, k + 1, nstk, ns, wcnext, (NInt) off, (NInt) 1 ^ n.args[1]);
+				add(ncsv, k + 1 + n.args[0], nstk, ns, wcnext, (NInt) off, (NInt) 0 ^ n.args[1]);
 				break;
 			case Node::SubL:
 				{

--- a/minrx.h
+++ b/minrx.h
@@ -49,7 +49,12 @@ typedef enum {				/* Flags for minrx_reg*comp() */
 	MINRX_REG_BRACK_ESCAPE = 64,	/* MinRX extension: bracket expressions [...] allow backslash escapes */
 	MINRX_REG_EXTENSIONS_BSD = 128,	/* MinRX extension: enable BSD extensions \< and \> */
 	MINRX_REG_EXTENSIONS_GNU = 256,	/* MinRX extension: enable GNU extensions \b \B \s \S \w \W */
-	MINRX_REG_NATIVE1B = 512	/* MinRX extension: use native encoding for 8-bit character sets (MB_CUR_LEN == 1) */
+	MINRX_REG_NATIVE1B = 512,	/* MinRX extension: use native encoding for 8-bit character sets (MB_CUR_LEN == 1) */
+	MINRX_REG_MINDISABLE = 1024,	/* MinRX extension: disable POSIX 2024 minimal repetitions */
+	MINRX_REG_MINGLOBAL = 2048,	/* MinRX extension: nexted minimization scope extends to top level / end of regexp */
+	MINRX_REG_MINSCOPED = 4096,	/* MinRX extension: nested minimization scope extends only up to next enclosing repetition (default) */
+	MINRX_REG_RPTMINFAST = 8192,	/* MinRX extension: repetitions containing minimized repetitions minimize number of minimized characters per outer repetition */
+	MINRX_REG_RPTMINSLOW = 16384	/* MinRX extension: repetitions containing minimized repetitions minimize total minimized characters across all outer repetitions */
 } minrx_regcomp_flags_t;
 
 typedef enum {				/* Flags for minrx_reg*exec() */

--- a/rxgrep.c
+++ b/rxgrep.c
@@ -3,7 +3,7 @@
  */
 
 /*
- * Copyright (C) 2024,
+ * Copyright (C) 2024, 2025,
  * Arnold David Robbins
  *
  * Redistribution and use in source and binary forms, with or without
@@ -33,6 +33,7 @@
 #include <stdio.h>
 #include <errno.h>
 #include <getopt.h>
+#include <locale.h>
 #include <regex.h>
 #include <stdbool.h>
 #include <stdlib.h>
@@ -44,8 +45,8 @@
 
 #include "minrx.h"
 
-#define VERSION		"0.2"
-#define COPYRIGHT_YEAR	2024
+#define VERSION		"0.3"
+#define COPYRIGHT_YEAR	2025
 
 /* The name the program was invoked under, for error messages */
 const char *myname;
@@ -97,6 +98,8 @@ main(int argc, char **argv)
 {
 	char **pattern_list = NULL;
 	int i;
+
+	(void) setlocale(LC_ALL, "");
 
 	parse_args(argc, argv);
 	set_syntax_flags();

--- a/tryit.c
+++ b/tryit.c
@@ -30,6 +30,16 @@ main(int argc, char *argv[])
 			cflags |= MINRX_REG_NEWLINE;
 		else if (strcmp(argv[1], "-r") == 0)
 			eflags |= MINRX_REG_NOSUBRESET;
+		else if (strcmp(argv[1], "--mindisable") == 0)
+			cflags |= MINRX_REG_MINDISABLE;
+		else if (strcmp(argv[1], "--minglobal") == 0)
+			cflags |= MINRX_REG_MINGLOBAL;
+		else if (strcmp(argv[1], "--minscoped") == 0)
+			cflags |= MINRX_REG_MINSCOPED;
+		else if (strcmp(argv[1], "--rptminfast") == 0)
+			cflags |= MINRX_REG_RPTMINFAST;
+		else if (strcmp(argv[1], "--rptminslow") == 0)
+			cflags |= MINRX_REG_RPTMINSLOW;
 		else if (strcmp(argv[1], "--gawk") == 0)
 			cflags |= MINRX_REG_EXTENSIONS_BSD | MINRX_REG_EXTENSIONS_GNU | MINRX_REG_BRACE_COMPAT | MINRX_REG_BRACK_ESCAPE;
 		--argc, ++argv;
@@ -44,8 +54,12 @@ main(int argc, char *argv[])
 		fprintf(stderr, "\t-f\tsubexpressions capture their first occurrence (rather than last)\n");
 		fprintf(stderr, "\t-i\tignore case\n");
 		fprintf(stderr, "\t-n\texclude newline from . and [^...] and treat as ^$ delimiter\n");
-		fprintf(stderr, "\t-r\trepeated subexpressions don't reset contained subexpressions\n");
-		fprintf(stderr, "\t--gawk\tequivalent to -B -G -c -e\n");
+		fprintf(stderr, "\t--mindisable\n\t\tenable the MINRX_REG_MINDISABLE compilation flag\n");
+		fprintf(stderr, "\t--minglobal\n\t\tenable the MINRX_REG_MINGLOBAL compilation flag\n");
+		fprintf(stderr, "\t--minscoped\n\t\tenable the MINRX_REG_MINSCOPED compilation flag\n");
+		fprintf(stderr, "\t--rptminfast\n\t\tenable the MINRX_REG_RPTMINFAST compilation flag\n");
+		fprintf(stderr, "\t--rptminslow\n\t\tenable the MINRX_REG_RPTMINSLOW compilation flag\n");
+		fprintf(stderr, "\t--gawk\n\t\tequivalent to -B -G -c -e\n");
 		exit(EXIT_FAILURE);
 	}
 	minrx_regex_t rx;


### PR DESCRIPTION
This should be a more portable way to check for UTF-8, as it does not rely on the name of the locale, which isn't standardized and can vary across operating systems.