### PR TITLE
Add flags for runtime debugging.

### DIFF
--- a/minrx.3
+++ b/minrx.3
@@ -1,4 +1,4 @@
-.TH MINRX 3 "July 2024"
+.TH MINRX 3 "March 2025"
 .SH NAME
 minrx \- A minimal POSIX-compliant matcher for extended regular expressions
 .SH SYNOPSIS
@@ -92,6 +92,12 @@ between compilation and execution.
 This will produce sensible results only in \f(CWLC_CTYPE\fP locales
 that have the same encodings as ASCII/ISO8859 for the regular expression
 special characters.
+.TP
+\f(CWMINRX_REG_DEBUG_COMP\fP
+Have
+.I MinRX
+print debugging statements during the compilation phase.
+This is a Minrx extension.
 .RE
 .PP
 The following values may be returned from
@@ -166,6 +172,12 @@ Don't match \f(CW$\fP at end of string.
 .TP
 \f(CWMINRX_REG_RESUME\fP
 Resume search from \f(CWrm[0].rm_eo\fP.
+This is a Minrx extension.
+.TP
+\f(CWMINRX_REG_DEBUG_EXEC\fP
+Have
+.I MinRX
+print debugging statements during the execution phase.
 This is a Minrx extension.
 .RE
 .PP

--- a/minrx.3
+++ b/minrx.3
@@ -93,6 +93,22 @@ This will produce sensible results only in \f(CWLC_CTYPE\fP locales
 that have the same encodings as ASCII/ISO8859 for the regular expression
 special characters.
 .TP
+\f(CWMINRX_REG_MINDISABLE\fP
+Disable POSIX 2024 minimal repetitions.
+.IP
+This option potentially enables better backwards compatibility
+with undefined behavior as implemented by certain widely-used
+pre-POSIX 2024 matchers.
+.IP
+In principle this flag is logically unnecessary, since all
+previous editions of the POSIX standard have stated that
+multiple adjacent repetition operators produce undefined results.
+POSIX 2024 added minimal repetitions by giving a new meaning to
+(only) this formerly-undefined syntax.  No regular expression
+that relies solely on defined behavior of earlier POSIX
+standards will have its meaning changed by the addition of
+minimal repetitions in POSIX 2024.
+.TP
 \f(CWMINRX_REG_DEBUG_COMP\fP
 Have
 .I MinRX

--- a/minrx.3
+++ b/minrx.3
@@ -1,4 +1,4 @@
-.TH MINRX 3 "March 2025"
+.TH MINRX 3 "July 2024"
 .SH NAME
 minrx \- A minimal POSIX-compliant matcher for extended regular expressions
 .SH SYNOPSIS

--- a/minrx.h
+++ b/minrx.h
@@ -50,7 +50,12 @@ typedef enum {				/* Flags for minrx_reg*comp() */
 	MINRX_REG_EXTENSIONS_BSD = 128,	/* MinRX extension: enable BSD extensions \< and \> */
 	MINRX_REG_EXTENSIONS_GNU = 256,	/* MinRX extension: enable GNU extensions \b \B \s \S \w \W */
 	MINRX_REG_NATIVE1B = 512,	/* MinRX extension: use native encoding for 8-bit character sets (MB_CUR_LEN == 1) */
-	MINRX_REG_DEBUG_COMP = 1024,	/* MinRX extension: get debug prints during compilation phase */
+	MINRX_REG_MINDISABLE = 1024,	/* MinRX extension: disable POSIX 2024 minimal repetitions */
+	MINRX_REG_MINGLOBAL = 2048,	/* MinRX extension: nexted minimization scope extends to top level / end of regexp */
+	MINRX_REG_MINSCOPED = 4096,	/* MinRX extension: nested minimization scope extends only up to next enclosing repetition (default) */
+	MINRX_REG_RPTMINFAST = 8192,	/* MinRX extension: repetitions containing minimized repetitions minimize number of minimized characters per outer repetition */
+	MINRX_REG_RPTMINSLOW = 16384,	/* MinRX extension: repetitions containing minimized repetitions minimize total minimized characters across all outer repetitions */
+	MINRX_REG_DEBUG_COMP = 32768,	/* MinRX extension: get debug prints during compilation phase */
 } minrx_regcomp_flags_t;
 
 typedef enum {				/* Flags for minrx_reg*exec() */

--- a/minrx.h
+++ b/minrx.h
@@ -49,7 +49,8 @@ typedef enum {				/* Flags for minrx_reg*comp() */
 	MINRX_REG_BRACK_ESCAPE = 64,	/* MinRX extension: bracket expressions [...] allow backslash escapes */
 	MINRX_REG_EXTENSIONS_BSD = 128,	/* MinRX extension: enable BSD extensions \< and \> */
 	MINRX_REG_EXTENSIONS_GNU = 256,	/* MinRX extension: enable GNU extensions \b \B \s \S \w \W */
-	MINRX_REG_NATIVE1B = 512	/* MinRX extension: use native encoding for 8-bit character sets (MB_CUR_LEN == 1) */
+	MINRX_REG_NATIVE1B = 512,	/* MinRX extension: use native encoding for 8-bit character sets (MB_CUR_LEN == 1) */
+	MINRX_REG_DEBUG_COMP = 1024,	/* MinRX extension: get debug prints during compilation phase */
 } minrx_regcomp_flags_t;
 
 typedef enum {				/* Flags for minrx_reg*exec() */
@@ -58,6 +59,7 @@ typedef enum {				/* Flags for minrx_reg*exec() */
 	MINRX_REG_FIRSTSUB = 4,		/* MinRX extension: repeated subexpressions capture their first occurrence (rather than last) */
 	MINRX_REG_NOSUBRESET = 8,	/* MinRX extension: repeated subexpressions don't clear their contained subexpressions */
 	MINRX_REG_RESUME = 16,		/* MinRX extension: resume search from rm[0].rm_eo */
+	MINRX_REG_DEBUG_EXEC = 32,	/* MinRX extension: get debug prints during execution phase */
 } minrx_regexec_flags_t;
 
 typedef enum {				/* Return values from minrx_reg*comp() and minrx_reg*exec() */

--- a/tryit.c
+++ b/tryit.c
@@ -30,6 +30,16 @@ main(int argc, char *argv[])
 			cflags |= MINRX_REG_NEWLINE;
 		else if (strcmp(argv[1], "-r") == 0)
 			eflags |= MINRX_REG_NOSUBRESET;
+		else if (strcmp(argv[1], "--mindisable") == 0)
+			cflags |= MINRX_REG_MINDISABLE;
+		else if (strcmp(argv[1], "--minglobal") == 0)
+			cflags |= MINRX_REG_MINGLOBAL;
+		else if (strcmp(argv[1], "--minscoped") == 0)
+			cflags |= MINRX_REG_MINSCOPED;
+		else if (strcmp(argv[1], "--rptminfast") == 0)
+			cflags |= MINRX_REG_RPTMINFAST;
+		else if (strcmp(argv[1], "--rptminslow") == 0)
+			cflags |= MINRX_REG_RPTMINSLOW;
 		else if (strcmp(argv[1], "--gawk") == 0)
 			cflags |= MINRX_REG_EXTENSIONS_BSD | MINRX_REG_EXTENSIONS_GNU | MINRX_REG_BRACE_COMPAT | MINRX_REG_BRACK_ESCAPE;
 		--argc, ++argv;
@@ -44,8 +54,12 @@ main(int argc, char *argv[])
 		fprintf(stderr, "\t-f\tsubexpressions capture their first occurrence (rather than last)\n");
 		fprintf(stderr, "\t-i\tignore case\n");
 		fprintf(stderr, "\t-n\texclude newline from . and [^...] and treat as ^$ delimiter\n");
-		fprintf(stderr, "\t-r\trepeated subexpressions don't reset contained subexpressions\n");
-		fprintf(stderr, "\t--gawk\tequivalent to -B -G -c -e\n");
+		fprintf(stderr, "\t--mindisable\n\t\tenable the MINRX_REG_MINDISABLE compilation flag\n");
+		fprintf(stderr, "\t--minglobal\n\t\tenable the MINRX_REG_MINGLOBAL compilation flag\n");
+		fprintf(stderr, "\t--minscoped\n\t\tenable the MINRX_REG_MINSCOPED compilation flag\n");
+		fprintf(stderr, "\t--rptminfast\n\t\tenable the MINRX_REG_RPTMINFAST compilation flag\n");
+		fprintf(stderr, "\t--rptminslow\n\t\tenable the MINRX_REG_RPTMINSLOW compilation flag\n");
+		fprintf(stderr, "\t--gawk\n\t\tequivalent to -B -G -c -e\n");
 		exit(EXIT_FAILURE);
 	}
 	minrx_regex_t rx;


### PR DESCRIPTION
Long ago, in the gawk version of GNU regex, I added an `RE_DEBUG` flag in order to be able to print debugging statements at runtime from the regex library.

That flag still exists in today's `<regex.h>` header file, although there is no longer any code in GNU regex itself that uses it.

This PR adds similar flags for MinRX, in case you think such a thing might be useful now, or later.

If not, feel free to close the PR and delete the branch.

Thanks!