### PR TITLE
Provide regcomp() flags controlling behavior of minimal repetitions

### DIFF
--- a/minrx.3
+++ b/minrx.3
@@ -92,6 +92,22 @@ between compilation and execution.
 This will produce sensible results only in \f(CWLC_CTYPE\fP locales
 that have the same encodings as ASCII/ISO8859 for the regular expression
 special characters.
+.TP
+\f(CWMINRX_REG_MINDISABLE\fP
+Disable POSIX 2024 minimal repetitions.
+.IP
+This option potentially enables better backwards compatibility
+with undefined behavior as implemented by certain widely-used
+pre-POSIX 2024 matchers.
+.IP
+In principle this flag is logically unnecessary, since all
+previous editions of the POSIX standard have stated that
+multiple adjacent repetition operators produce undefined results.
+POSIX 2024 added minimal repetitions by giving a new meaning to
+(only) this formerly-undefined syntax.  No regular expression
+that relies solely on defined behavior of earlier POSIX
+standards will have its meaning changed by the addition of
+minimal repetitions in POSIX 2024.
 .RE
 .PP
 The following values may be returned from

--- a/minrx.h
+++ b/minrx.h
@@ -49,7 +49,12 @@ typedef enum {				/* Flags for minrx_reg*comp() */
 	MINRX_REG_BRACK_ESCAPE = 64,	/* MinRX extension: bracket expressions [...] allow backslash escapes */
 	MINRX_REG_EXTENSIONS_BSD = 128,	/* MinRX extension: enable BSD extensions \< and \> */
 	MINRX_REG_EXTENSIONS_GNU = 256,	/* MinRX extension: enable GNU extensions \b \B \s \S \w \W */
-	MINRX_REG_NATIVE1B = 512	/* MinRX extension: use native encoding for 8-bit character sets (MB_CUR_LEN == 1) */
+	MINRX_REG_NATIVE1B = 512,	/* MinRX extension: use native encoding for 8-bit character sets (MB_CUR_LEN == 1) */
+	MINRX_REG_MINDISABLE = 1024,	/* MinRX extension: disable POSIX 2024 minimal repetitions */
+	MINRX_REG_MINGLOBAL = 2048,	/* MinRX extension: nexted minimization scope extends to top level / end of regexp */
+	MINRX_REG_MINSCOPED = 4096,	/* MinRX extension: nested minimization scope extends only up to next enclosing repetition (default) */
+	MINRX_REG_RPTMINFAST = 8192,	/* MinRX extension: repetitions containing minimized repetitions minimize number of minimized characters per outer repetition */
+	MINRX_REG_RPTMINSLOW = 16384	/* MinRX extension: repetitions containing minimized repetitions minimize total minimized characters across all outer repetitions */
 } minrx_regcomp_flags_t;
 
 typedef enum {				/* Flags for minrx_reg*exec() */

--- a/tryit.c
+++ b/tryit.c
@@ -30,6 +30,16 @@ main(int argc, char *argv[])
 			cflags |= MINRX_REG_NEWLINE;
 		else if (strcmp(argv[1], "-r") == 0)
 			eflags |= MINRX_REG_NOSUBRESET;
+		else if (strcmp(argv[1], "--mindisable") == 0)
+			cflags |= MINRX_REG_MINDISABLE;
+		else if (strcmp(argv[1], "--minglobal") == 0)
+			cflags |= MINRX_REG_MINGLOBAL;
+		else if (strcmp(argv[1], "--minscoped") == 0)
+			cflags |= MINRX_REG_MINSCOPED;
+		else if (strcmp(argv[1], "--rptminfast") == 0)
+			cflags |= MINRX_REG_RPTMINFAST;
+		else if (strcmp(argv[1], "--rptminslow") == 0)
+			cflags |= MINRX_REG_RPTMINSLOW;
 		else if (strcmp(argv[1], "--gawk") == 0)
 			cflags |= MINRX_REG_EXTENSIONS_BSD | MINRX_REG_EXTENSIONS_GNU | MINRX_REG_BRACE_COMPAT | MINRX_REG_BRACK_ESCAPE;
 		--argc, ++argv;
@@ -44,8 +54,12 @@ main(int argc, char *argv[])
 		fprintf(stderr, "\t-f\tsubexpressions capture their first occurrence (rather than last)\n");
 		fprintf(stderr, "\t-i\tignore case\n");
 		fprintf(stderr, "\t-n\texclude newline from . and [^...] and treat as ^$ delimiter\n");
-		fprintf(stderr, "\t-r\trepeated subexpressions don't reset contained subexpressions\n");
-		fprintf(stderr, "\t--gawk\tequivalent to -B -G -c -e\n");
+		fprintf(stderr, "\t--mindisable\n\t\tenable the MINRX_REG_MINDISABLE compilation flag\n");
+		fprintf(stderr, "\t--minglobal\n\t\tenable the MINRX_REG_MINGLOBAL compilation flag\n");
+		fprintf(stderr, "\t--minscoped\n\t\tenable the MINRX_REG_MINSCOPED compilation flag\n");
+		fprintf(stderr, "\t--rptminfast\n\t\tenable the MINRX_REG_RPTMINFAST compilation flag\n");
+		fprintf(stderr, "\t--rptminslow\n\t\tenable the MINRX_REG_RPTMINSLOW compilation flag\n");
+		fprintf(stderr, "\t--gawk\n\t\tequivalent to -B -G -c -e\n");
 		exit(EXIT_FAILURE);
 	}
 	minrx_regex_t rx;


### PR DESCRIPTION
MINRX_REG_MINDISABLE

	Disable POSIX 2024 minimal repetitions altogether.

	This option potentially enables better backwards compatibility
	with undefined behavior as implemented by certain widely-used
	pre-POSIX 2024 matchers.

	In principle this flag is logically unnecessary, since all
	previous editions of the POSIX standard have stated that
	multiple adjacent repetition operators produce undefined results.
	POSIX 2024 added minimal repetitions by giving a new meaning to
	(only) this formerly-undefined syntax.	No regular expression
	that relies solely on *defined* behavior of earlier POSIX
	standards will have its meaning changed by the addition of
	minimal repetitions in POSIX 2024.

	It is an error to specify this flag together with any of the
	other flags controlling minimal repetitions.

MINRX_REG_MINGLOBAL

	The minimization due to a minimal repetition extends all the
	way to the end of the match even if the minimal repetition is
	nested inside non-minimal repetition(s).  For example with this
	flag '(a*?)*' matched against 'aaa' will match '', because the
	inner repetition's minimization overrides the outer repetition's
	maximization.

	It is an error to specify both this flag and MINRX_REG_MINSCOPED.

MINRX_REG_MINSCOPED

	The minimization due to a minimal repetition is limited in
	scope only up to the next enclosing non-minimal repetition.
	For example '(a*?)*' matched against 'aaa' will match 'aaa',
	because the outer repetition's maximization overrides the inner
	reptition's minimization.

	The behavior with MINRX_REG_MINSCOPED is closer in philosophy to
	the rest of the POSIX regular expression standard, throughout
	which optimizing the outcomes of containing constructs takes
	precedence over optimizing the outcomes of contained constructs.
	MINRX_REG_MINSCOPED also results in fewer surprises when combining
	smaller regular expressions to construct larger ones.

	It is an error to specify both this flag and MINRX_REG_MINGLOBAL.

MINRX_REG_RPTMINFAST

	When an outer repetition encloses inner minimal repetition(s),
	the outer repetition will repeat "faster" (fewer character per
	outer repetition), so as to minimize the number of characters
	matched by inner minimal repetition(s) per outer repetition.

	With this option '(a*?)*b' matched to 'aab' will return (1,2)
	for the substring matched by the parenthesized subpattern.

	It is an error to specify both this flag and MINRX_REG_RPTMINSLOW.

MINRX_REG_RPTMINSLOW

	When an outer repetition encloses an inner minimal repetition,
	the outer repetition will attempt to minimize the total number of
	characters matched by the inner minimal repetition(s) across all
	outer repetitions, but it will not try to minimize the number
	of minimal characters matched in each separate occurrence of
	the inner minimal repetition.

	With this option '(a*?)*b' matched to 'aab' will return (0,2)
	for the substring matched by the parenthesized subpattern.

	It is an error to specify both this flag and MINRX_REG_RPTMINFAST.

The 'tryit' program adds options --mindisable, --minglobal, --minscoped, --rptminfast, and --rptminslow corresponding to the above options:

$ ./tryit --minglobal --rptminfast '((a*?)*b)*' aabaab (0,3)(0,3)(1,2)

$ ./tryit --minglobal --rptminslow '((a*?)*b)*' aabaab (0,3)(0,3)(0,2)

$ ./tryit --minscoped --rptminfast '((a*?)*b)*' aabaab  # this is default (0,6)(3,6)(4,5)

$ ./tryit --minscoped --rptminslow '((a*?)*b)*' aabaab (0,6)(3,6)(3,5)

Currently MinRX default behavior for minimal repetitions corresponds to MINRX_REG_MINSCOPED | MINRX_REG_RPTMINFAST.  These defaults may change in the future depending on new interpretations from POSIX.