### PR TITLE
Small fixes to improve the code a little bit.

### DIFF
--- a/minrx.cpp
+++ b/minrx.cpp
@@ -90,7 +90,7 @@ bool IsDigit(int32_t wc)
 	return wc >= L'0' && wc <= L'9';
 }
 
-#if 0
+#ifdef __GNUC__
 // FIXME: expand compiler support beyond clang and gcc
 #if UINT_MAX == 18446744073709551615U
 #define ctz __builtin_ctz
@@ -108,20 +108,22 @@ int
 ctz(uint64_t val)
 {
 	static char table[] = {
-		8, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0, 4, 0,
-		1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0, 5, 0, 1, 0,
-		2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0, 4, 0, 1, 0, 2, 0,
-		1, 0, 3, 0, 1, 0, 2, 0, 1, 0, 6, 0, 1, 0, 2, 0, 1, 0,
-		3, 0, 1, 0, 2, 0, 1, 0, 4, 0, 1, 0, 2, 0, 1, 0, 3, 0,
-		1, 0, 2, 0, 1, 0, 5, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0,
-		2, 0, 1, 0, 4, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0,
-		1, 0, 7, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0,
-		4, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0, 5, 0,
-		1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0, 4, 0, 1, 0,
-		2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0, 6, 0, 1, 0, 2, 0, 1,
-		0, 3, 0, 1, 0, 2, 0, 1, 0, 4, 0, 1, 0, 2, 0, 1, 0, 3, 0,
-		1, 0, 2, 0, 1, 0, 5, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2,
-		0, 1, 0, 4, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0,
+		8, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0,
+		4, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0,
+		5, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0,
+		4, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0,
+		6, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0,
+		4, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0,
+		5, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0,
+		4, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0,
+		7, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0,
+		4, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0,
+		5, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0,
+		4, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0,
+		6, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0,
+		4, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0,
+		5, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0,
+		4, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0,
 	};
 
 	if (val == 0)
@@ -366,7 +368,7 @@ bit(size_t k)
 static bool
 qset_empty(const QSet *q)
 {
-	return !q->bits0;
+	return q->bits0 == 0;
 }
 
 static bool
@@ -375,7 +377,7 @@ qset_contains(const QSet *q, size_t k)
 	int i = 0, s = 6 * q->depth;
 	size_t j = 0;
 	while (i < q->depth) {
-		auto x = q->bits[i++][j];
+		int64_t x = q->bits[i++][j];
 		s -= 6;
 		j = k >> s;
 		auto w = bit(j);
@@ -392,11 +394,11 @@ qset_insert(QSet *q, size_t k)
 	int i = 0, s = 6 * q->depth;
 	size_t j = 0;
 	while (i < q->depth) {
-		auto bp = &q->bits[i++][j];
-		auto x = *bp;
+		uint64_t *bp = &q->bits[i++][j];
+		uint64_t x = *bp;
 		s -= 6;
 		j = k >> s;
-		auto w = bit(j);
+		uint64_t w = bit(j);
 		if ((x & w) == 0) {
 			if (i < q->depth)
 				q->bits[i][j] = 0;
@@ -419,7 +421,7 @@ qset_remove(QSet *q) // caller must ensure !empty()
 	size_t r = k;
 	do {
 		--i;
-		auto w = bit(k);
+		uint64_t w = bit(k);
 		k >>= 6;
 		if ((q->bits[i][k] &= ~w) != 0)
 			break;
@@ -508,7 +510,7 @@ static void
 qvec_clear(QVec *q)
 {
 	while (!qset_empty(&q->qset)) {
-		auto i = qset_remove(&q->qset);
+		size_t i = qset_remove(&q->qset);
 		nstate_destruct(&q->storage[i]);
 	}
 }
@@ -545,7 +547,7 @@ qvec_lookup(QVec *q, size_t k)
 static std::pair<size_t, NState>
 qvec_remove(QVec *q)
 {
-	auto k = qset_remove(&q->qset);
+	size_t k = qset_remove(&q->qset);
 	std::pair<size_t, NState> r {k, {}};
 	nstate_construct_move(&r.second, &q->storage[k]);
 	return r;
@@ -576,7 +578,7 @@ wconv_nextmbtowc(WConv *wc)
 {
 	wchar_t wct = L'\0';
 	if (wc->cp != wc->ep) {
-		auto n = mbrtowc(&wct, wc->cp, wc->ep - wc->cp, &wc->mbs);
+		size_t n = mbrtowc(&wct, wc->cp, wc->ep - wc->cp, &wc->mbs);
 		if (n == 0 || n == (size_t) -1 || n == (size_t) -2) {
 			if (wct == L'\0')
 				wct = std::numeric_limits<WChar>::min() + (unsigned char) *wc->cp++;
@@ -662,7 +664,7 @@ wconv_nextchr(WConv *wc)
 static WChar
 wconv_lookahead(WConv *wc)
 {
-	auto wconv(*wc);
+	WConv wconv = *wc;
 	return wconv_nextchr(&wconv);
 }
 

--- a/minrx.cpp
+++ b/minrx.cpp
@@ -70,14 +70,6 @@
 #include "charset.h"
 #endif
 
-#ifdef GAWK
-// Work around Gawk's use of a nonstandard allocator that probably lacks
-// extern "C" declarations for its functions.
-#undef free
-#undef malloc
-#undef realloc
-#endif
-
 #include "minrx.h"
 
 #ifdef __GNUC__

--- a/minrx.cpp
+++ b/minrx.cpp
@@ -81,10 +81,14 @@
 #include "minrx.h"
 
 #ifdef __GNUC__
-#define INLINE __attribute__((__always_inline__)) inline
-#else
-#define INLINE inline
+#define inline __attribute__((__always_inline__)) inline
 #endif
+
+static inline
+bool IsDigit(int32_t wc)
+{
+	return wc >= L'0' && wc <= L'9';
+}
 
 // FIXME: expand compiler support beyond clang and gcc
 #if UINT_MAX == 18446744073709551615U
@@ -1243,7 +1247,7 @@ struct Compile {
 				continue;
 			case L'{':
 				if ((flags & MINRX_REG_BRACE_COMPAT) == 0
-				    || (enc == Byte ? isdigit(wconv_lookahead(&wconv)) : iswdigit(wconv_lookahead(&wconv))))
+				    || (enc == Byte ? isdigit(wconv_lookahead(&wconv)) : IsDigit(wconv_lookahead(&wconv))))
 				{
 					wc = wconv_nextchr(&wconv);
 					if (wc == End)
@@ -1322,7 +1326,7 @@ struct Compile {
 			break;
 		case L'{':
 			if ((flags & MINRX_REG_BRACE_COMPAT) != 0
-			    && (enc == Byte ? !isdigit(wconv_lookahead(&wconv)) : !iswdigit(wconv_lookahead(&wconv))))
+			    && (enc == Byte ? !isdigit(wconv_lookahead(&wconv)) : !IsDigit(wconv_lookahead(&wconv))))
 				goto normal;
 			// fall through
 		case L'*':
@@ -1616,7 +1620,7 @@ execute_destruct(Execute *e)
 }
 
 template <typename... XArgs>
-INLINE static void
+inline static void
 execute_add(Execute *e, QVec &ncsv, NInt k, NInt nstk, const NState *nsp, WChar wcnext, XArgs... xargs)
 {
 	const Node &n = e->nodes[k];
@@ -1951,7 +1955,8 @@ minrx_regncomp(minrx_regex_t *rx, size_t ns, const char *s, int flags)
 {
 	auto enc = MinRX::MBtoWC;
 	auto loc = setlocale(LC_CTYPE, nullptr);
-	if ((strcmp(loc, "C") == 0 || (flags & MINRX_REG_NATIVE1B) != 0) && MB_CUR_MAX == 1)
+	if ((strcmp(loc, "C") == 0 || strcmp(loc, "POSIX") == 0 ||
+		(flags & MINRX_REG_NATIVE1B) != 0) && MB_CUR_MAX == 1)
 		enc = MinRX::Byte;
 	else if (strcmp(nl_langinfo(CODESET), "UTF-8") == 0)
 		enc = MinRX::UTF8;

--- a/minrx.cpp
+++ b/minrx.cpp
@@ -90,6 +90,7 @@ bool IsDigit(int32_t wc)
 	return wc >= L'0' && wc <= L'9';
 }
 
+#if 0
 // FIXME: expand compiler support beyond clang and gcc
 #if UINT_MAX == 18446744073709551615U
 #define ctz __builtin_ctz
@@ -99,6 +100,48 @@ bool IsDigit(int32_t wc)
 #define ctz __builtin_ctzll
 #else
 #error "can't figure out how to count trailing zeroes for 64-bit operands"
+#endif
+#else
+// ctz --- count trailing zeros. dead simple table driven version
+
+int
+ctz(uint64_t val)
+{
+	static char table[] = {
+		8, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0, 4, 0,
+		1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0, 5, 0, 1, 0,
+		2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0, 4, 0, 1, 0, 2, 0,
+		1, 0, 3, 0, 1, 0, 2, 0, 1, 0, 6, 0, 1, 0, 2, 0, 1, 0,
+		3, 0, 1, 0, 2, 0, 1, 0, 4, 0, 1, 0, 2, 0, 1, 0, 3, 0,
+		1, 0, 2, 0, 1, 0, 5, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0,
+		2, 0, 1, 0, 4, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0,
+		1, 0, 7, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0,
+		4, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0, 5, 0,
+		1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0, 4, 0, 1, 0,
+		2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0, 6, 0, 1, 0, 2, 0, 1,
+		0, 3, 0, 1, 0, 2, 0, 1, 0, 4, 0, 1, 0, 2, 0, 1, 0, 3, 0,
+		1, 0, 2, 0, 1, 0, 5, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2,
+		0, 1, 0, 4, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0,
+	};
+
+	if (val == 0)
+		return 64;
+
+	int count = 0;
+	for (; val != 0; val >>= 8) {
+		uint32_t x = val & 0xFF;
+
+		if (x == 0) {
+			count += 8;
+			continue;
+		}
+		
+		count += table[x];
+		break;
+	}
+
+	return count;
+}
 #endif
 
 #define MAX(A, B) ((A) >= (B) ? (A) : (B))

--- a/minrx.cpp
+++ b/minrx.cpp
@@ -221,7 +221,7 @@ cowvec_storage_alloc(COWVec_Allocator *a)
 static COWVec_Storage *
 cowvec_storage_clone(COWVec_Storage *cvs)
 {
-	auto newcvs = cowvec_storage_alloc(cvs->u.allocator);
+	COWVec_Storage *newcvs = cowvec_storage_alloc(cvs->u.allocator);
 	for (size_t i = 0, n = cvs->u.allocator->length; i != n; ++i)
 		cowvec_storage_put(newcvs, i, cowvec_storage_get(cvs, i));
 	return newcvs;
@@ -372,7 +372,7 @@ qset_contains(const QSet *q, size_t k)
 		int64_t x = q->bits[i++][j];
 		s -= 6;
 		j = k >> s;
-		auto w = bit(j);
+		int64_t w = bit(j);
 		if (!(x & w))
 			return false;
 	}
@@ -843,14 +843,14 @@ struct CSet {
 	}
 #endif
 	minrx_result_t parse(minrx_regcomp_flags_t flags, WConv_Encoding enc, WConv &wconv) {
-		auto wc = wconv_nextchr(&wconv);
+		WChar wc = wconv_nextchr(&wconv);
 		bool inv = wc == L'^';
 		if (inv)
 			wc = wconv_nextchr(&wconv);
 		for (bool first = true; first || wc != L']'; first = false) {
 			if (wc == End)
 				return MINRX_REG_EBRACK;
-			auto wclo = wc, wchi = wc;
+			WChar wclo = wc, wchi = wc;
 			wc = wconv_nextchr(&wconv);
 			if (wclo == L'\\' && (flags & MINRX_REG_BRACK_ESCAPE) != 0) {
 				if (wc != End) {
@@ -879,7 +879,7 @@ struct CSet {
 						return MINRX_REG_ECOLLATE;
 					wc = wconv_nextchr(&wconv);
 				} else if (wc == L':') {
-					auto bp = wconv_ptr(&wconv), ep = bp;
+					const char *bp = wconv_ptr(&wconv), *ep = bp;
 					do
 						ep = wconv_ptr(&wconv), wc = wconv_nextchr(&wconv);
 					while (wc != End && wc != L':');
@@ -920,7 +920,7 @@ struct CSet {
 			}
 			bool range = false;
 			if (wc == L'-') {
-				auto save = wconv_save(&wconv);
+				const char *save = wconv_save(&wconv);
 				wc = wconv_nextchr(&wconv);
 				if (wc == End)
 					return MINRX_REG_EBRACK;
@@ -956,7 +956,7 @@ struct CSet {
 			if (wclo >= 0) {
 				set(wclo, wchi);
 				if ((flags & MINRX_REG_ICASE) != 0) {
-					for (auto wc = wclo; wc <= wchi; ++wc) {
+					for (WChar wc = wclo; wc <= wchi; ++wc) {
 						set(enc == Byte ? tolower(wc) : towlower(wc));
 						set(enc == Byte ? toupper(wc) : towupper(wc));
 					}


### PR DESCRIPTION
Change `INLINE` to `inline`.
Check for `"POSIX"` locale too.
Use only the regular western digits when testing a wide character. `iswdigit()` can allow other kinds of digits.

After trying to use two different `ctz()` routines from _Hacker's Delight_, I gave up and wrote a dead simple table driven version.  This one passes `make check` in the gawk feature/minrx branch.