### PR TITLE
Remove use of std::string via new additional charset API.

### DIFF
--- a/charset.c
+++ b/charset.c
@@ -3969,6 +3969,30 @@ charset_add_cclass(charset_t *set, const char *cclass)
 
 	return CSET_SUCCESS;
 }
+/* charset_add_cclass2 --- get class name from unterminated string */
+
+Static int
+charset_add_cclass2(charset_t *set, const char *bp, const char *ep)
+{
+	if (bp == NULL || ep == NULL || bp >= ep)
+		return CSET_EBADPTR;
+
+#define ARBITRARY_LIMIT	101		// 100 + '\0'
+	char cclass[ARBITRARY_LIMIT];
+
+	if (ep - bp >= ARBITRARY_LIMIT)
+		return CSET_ECTYPE;
+
+	int i;
+	for (i = 0; bp < ep; i++, bp++)
+		cclass[i] = *bp;
+	
+	cclass[i] = '\0';
+
+	return charset_add_cclass(set, cclass);
+
+#undef ARBITRARY_LIMIT
+}
 /* charset_copy --- create a new charset that is copy of the original */
 
 Static charset_t *

--- a/charset.h
+++ b/charset.h
@@ -62,6 +62,7 @@ Static int charset_set_no_newlines(charset_t *set, bool no_newlines);
 Static int charset_add_equiv(charset_t *set, int32_t equiv);
 Static int charset_add_collate(charset_t *set, const int32_t *collate);
 Static int charset_add_cclass(charset_t *set, const char *cclass);
+Static int charset_add_cclass2(charset_t *set, const char *bp, const char *ep);
 Static charset_t *charset_copy(charset_t *set, int *errcode);
 Static int charset_merge(charset_t *dest, charset_t *src);
 Static bool charset_in_set(const charset_t *set, int32_t the_char);

--- a/minrx.cpp
+++ b/minrx.cpp
@@ -40,7 +40,6 @@
 #include <limits>
 #include <map>
 #include <optional>
-#include <string>
 #include <tuple>
 #include <vector>
 
@@ -716,12 +715,12 @@ struct CSet {
 	bool test(WChar wc) const {
 		return charset_in_set(charset, wc);
 	}
-	bool cclass(minrx_regcomp_flags_t flags, WConv_Encoding, const std::string &name) {
-		int result = charset_add_cclass(charset, name.c_str());
+	bool cclass(minrx_regcomp_flags_t flags, WConv_Encoding, const char *bp, const char *ep) {
+		int result = charset_add_cclass2(charset, bp, ep);
 		if ((flags & MINRX_REG_ICASE) != 0) {
-			if (name == "lower")
+			if (strncmp(bp, "lower", 5) == 0)
 				charset_add_cclass(charset, "upper");	// FIXME: Add error checking
-			else if (name == "upper")
+			else if (strncmp(bp, "upper", 5) == 0)
 				charset_add_cclass(charset, "lower");	// FIXME: Add error checking
 		}
 		return result == CSET_SUCCESS;
@@ -788,8 +787,7 @@ struct CSet {
 					if (wc != L']')
 						return MINRX_REG_ECTYPE;
 					wc = wconv_nextchr(&wconv);
-					auto cclname = std::string(bp, ep);
-					if (cclass(flags, enc, cclname))
+					if (cclass(flags, enc, bp, ep))
 						continue;
 					return MINRX_REG_ECTYPE;
 				} else if (wc == L'=') {


### PR DESCRIPTION
Use new charset API that doesn't require NUL-terminated class name.  This allows us to remove the use of C++ std::string.
The updated charset.h and charset.c files are also included. They're identical to what's in the charset Git repo.