### PR TITLE
Remove use of std::map and icmap variable.

### DIFF
--- a/charset.c
+++ b/charset.c
@@ -3739,6 +3739,40 @@ charset_add_char(charset_t *set, int32_t wc)
 
 	return CSET_SUCCESS;
 }
+/* charset_add_char_ic --- add a single wide character to the set, and its case alternatives */
+
+Static int
+charset_add_char_ic(charset_t *set, int32_t wc)
+{
+	if (set == NULL)
+		return CSET_EBADPTR;
+	if (set->finalized)
+		return CSET_EFROZEN;
+
+	if (wc < 0)
+		return CSET_ERANGE;
+
+	int result1 = charset_add_char(set, wc);
+
+	if (result1 == CSET_SUCCESS) {
+		int result2, result3;
+		result2 = result3 = CSET_SUCCESS;
+
+		int32_t wcl = set->mb_cur_max == 1 ? tolower(wc) : (int32_t) towlower(wc);
+		int32_t wcu = set->mb_cur_max == 1 ? toupper(wc) : (int32_t) towupper(wc);
+
+		if (wc != wcl || wc != wcu) {
+			result2 = charset_add_char(set, wcl);
+			result3 = charset_add_char(set, wcu);
+		}
+		if (result3 != CSET_SUCCESS)
+			return result3;
+		if (result2 != CSET_SUCCESS)
+			return result2;
+	}
+
+	return result1;
+}
 /* charset_add_range --- add a range item */
 
 Static int
@@ -3968,6 +4002,30 @@ charset_add_cclass(charset_t *set, const char *cclass)
 	}
 
 	return CSET_SUCCESS;
+}
+/* charset_add_cclass2 --- get class name from unterminated string */
+
+Static int
+charset_add_cclass2(charset_t *set, const char *bp, const char *ep)
+{
+	if (bp == NULL || ep == NULL || bp >= ep)
+		return CSET_EBADPTR;
+
+#define ARBITRARY_LIMIT	101		// 100 + '\0'
+	char cclass[ARBITRARY_LIMIT];
+
+	if (ep - bp >= ARBITRARY_LIMIT)
+		return CSET_ECTYPE;
+
+	int i;
+	for (i = 0; bp < ep; i++, bp++)
+		cclass[i] = *bp;
+	
+	cclass[i] = '\0';
+
+	return charset_add_cclass(set, cclass);
+
+#undef ARBITRARY_LIMIT
 }
 /* charset_copy --- create a new charset that is copy of the original */
 

--- a/charset.h
+++ b/charset.h
@@ -56,12 +56,14 @@ enum {
 };
 Static charset_t *charset_create(int *errcode, int mb_cur_max, bool is_utf8);
 Static int charset_add_char(charset_t *set, int32_t wc);
+Static int charset_add_char_ic(charset_t *set, int32_t wc);
 Static int charset_add_range(charset_t *set, int32_t first, int32_t last);
 Static charset_t *charset_invert(charset_t *set, int *errcode);
 Static int charset_set_no_newlines(charset_t *set, bool no_newlines);
 Static int charset_add_equiv(charset_t *set, int32_t equiv);
 Static int charset_add_collate(charset_t *set, const int32_t *collate);
 Static int charset_add_cclass(charset_t *set, const char *cclass);
+Static int charset_add_cclass2(charset_t *set, const char *bp, const char *ep);
 Static charset_t *charset_copy(charset_t *set, int *errcode);
 Static int charset_merge(charset_t *dest, charset_t *src);
 Static bool charset_in_set(const charset_t *set, int32_t the_char);

--- a/minrx.cpp
+++ b/minrx.cpp
@@ -38,7 +38,6 @@
 
 // ISO C++
 #include <limits>
-#include <map>
 #include <optional>
 #include <string>
 #include <tuple>
@@ -709,8 +708,11 @@ struct CSet {
 		charset_add_range(charset, wclo, wchi);	// FIXME: no error checking
 		return *this;
 	}
-	CSet &set(WChar wc) {
-		charset_add_char(charset, wc);	// FIXME: no error checking
+	CSet &set(WChar wc, bool ignore_case = false) {
+		if (ignore_case)
+			charset_add_char_ic(charset, wc);	// FIXME: no error checking
+		else
+			charset_add_char(charset, wc);	// FIXME: no error checking
 		return *this;
 	}
 	bool test(WChar wc) const {
@@ -1072,7 +1074,6 @@ struct Compile {
 	std::optional<size_t> esc_S;
 	std::optional<size_t> esc_w;
 	std::optional<size_t> esc_W;
-	std::map<WChar, unsigned int> icmap;
 	NInt nmin = 0;
 	NInt nsub = 0;
 	NodePool *np = 0;
@@ -1344,23 +1345,10 @@ struct Compile {
 				if (!emplace_first(&np, &lhs, (NInt) wc, 0, 0, nstk))
 					return {empty(), 0, false, MINRX_REG_ESPACE};
 			} else {
-				WChar wcl = enc == Byte ? tolower(wc) : towlower(wc);
-				WChar wcu = enc == Byte ? toupper(wc) : towupper(wc);
-				if (wc != wcl || wc != wcu) {
-					auto key = MIN(wc, MIN(wcl, wcu));
-					if (icmap.find(key) == icmap.end()) {
-						icmap.emplace(key, csets.size());
-						csets.emplace_back(enc);
-						csets.back().set(wc);
-						csets.back().set(wcl);
-						csets.back().set(wcu);
-					}
-					if (!emplace_final(&np, &lhs, Node::CSet, icmap[key], 0, nstk))
-						return {empty(), 0, false, MINRX_REG_ESPACE};
-				} else {
-					if (!emplace_final(&np, &lhs, (NInt) wc, 0, 0, nstk))
-						return {empty(), 0, false, MINRX_REG_ESPACE};
-				}
+				csets.emplace_back(enc);
+				csets.back().set(wc, true);
+				if (!emplace_final(&np, &lhs, Node::CSet, csets.size() - 1, 0, nstk))
+					return {empty(), 0, false, MINRX_REG_ESPACE};
 			}
 			wc = wconv_nextchr(&wconv);
 			break;


### PR DESCRIPTION
Remove need for std::map.  The charset.[ch] files here also have the changes from #47.  Git should straighten things out if they are merged in order.