### PR TITLE
Fix minrx.cpp so that equivalence classes work.

### DIFF
--- a/minrx.cpp
+++ b/minrx.cpp
@@ -805,6 +805,7 @@ struct CSet {
 					wc = wconv_nextchr(&wconv);
 					if (wc != L'=' || (wc = wconv_nextchr(&wconv)) != L']')
 						return MINRX_REG_ECOLLATE;
+					wc = wconv_nextchr(&wconv);
 				}
 			}
 			bool range = false;


### PR DESCRIPTION
With this fix, [[=e=]] in a regex now works.