### PR TITLE
Return an error for invalid bytes in a regexp.

### DIFF
--- a/minrx.c
+++ b/minrx.c
@@ -1589,7 +1589,7 @@ chr(Compile *c, bool nested, NInt nstk)
 				return LITERAL(Subexp) {empty(), 0, false, MINRX_REG_ESPACE};
 		}
 		if (c->wc >= INT32_MIN && c->wc <= INT32_MIN + 255) {
-			err = MINRX_REG_BADPAT;		// invalid char seen
+			err = MINRX_REG_BADPAT;		// invalid byte seen
 			goto done;
 		}
 		c->wc = wconv_nextchr(&c->wconv);

--- a/minrx.c
+++ b/minrx.c
@@ -1574,6 +1574,7 @@ chr(Compile *c, bool nested, NInt nstk)
 	NodeList lhs = empty();
 	size_t lhmaxstk;
 	bool lhasmin = false;
+	minrx_result_t err = MINRX_REG_SUCCESS;
 	switch (c->wc) {
 	default:
 	normal:
@@ -1586,6 +1587,10 @@ chr(Compile *c, bool nested, NInt nstk)
 			cset_set_ic(csets_back(&c->csets), c->wc);
 			if (!emplace_final(&c->np, &lhs, Cset, csets_size(&c->csets) - 1, 0, nstk))
 				return LITERAL(Subexp) {empty(), 0, false, MINRX_REG_ESPACE};
+		}
+		if (c->wc >= INT32_MIN && c->wc <= INT32_MIN + 255) {
+			err = MINRX_REG_BADPAT;		// invalid char seen
+			goto done;
 		}
 		c->wc = wconv_nextchr(&c->wconv);
 		break;
@@ -1762,7 +1767,8 @@ chr(Compile *c, bool nested, NInt nstk)
 		lhmaxstk = nstk;
 		break;
 	}
-	return LITERAL(Subexp) {lhs, lhmaxstk, lhasmin, MINRX_REG_SUCCESS};
+done:
+	return LITERAL(Subexp) {lhs, lhmaxstk, lhasmin, err};
 }
 
 static void


### PR DESCRIPTION
Add error checking for invalid bytes in a regexp.  This helps avoid core dumps when matching such a pattern, since the pattern now won't compile in the first place.