### PR TITLE
Define _POSIX_C_SOURCE=200809L to fix undeclared RE_DUP_MAX error with GCC 16

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,9 @@ builds/$(TYPE)/meson-info:
 	meson setup builds/$(TYPE) --prefix=$(PREFIX) --buildtype=$(TYPE)
 
 # traditional build (requires only make): make tryit
-CFLAGS=-O3 -Wall
-CXXFLAGS=-std=c++20 -O3 -Wall
+CFLAGS=-O3 -Wall -D_POSIX_C_SOURCE=200809L
+CXXFLAGS=-std=c++20 -O3 -Wall -D_POSIX_C_SOURCE=200809L
+
 rxgrep: minrx.o rxgrep.o
 	$(CXX) -o $@ $^
 tryit: minrx.o tryit.o


### PR DESCRIPTION
Fixes #59