### PR TITLE
Remove warning for charset, bug fix in minrx.c.

### DIFF
--- a/charset.c
+++ b/charset.c
@@ -8910,6 +8910,8 @@ charset_add_char(charset_t *set, int32_t wc)
 }
 /* charset_add_char_ic --- add a single wide character to the set, and its case alternatives */
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-function"
 Static int
 charset_add_char_ic(charset_t *set, int32_t wc)
 {
@@ -8942,8 +8944,7 @@ charset_add_char_ic(charset_t *set, int32_t wc)
 
 	return result1;
 }
-
-
+#pragma GCC diagnostic pop
 /* charset_add_range --- add a range item */
 
 Static int

--- a/charset.h
+++ b/charset.h
@@ -56,7 +56,10 @@ enum {
 };
 Static charset_t *charset_create(int *errcode, int mb_cur_max, bool is_utf8);
 Static int charset_add_char(charset_t *set, int32_t wc);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-function"
 Static int charset_add_char_ic(charset_t *set, int32_t wc);
+#pragma GCC diagnostic pop
 Static int charset_add_range(charset_t *set, int32_t first, int32_t last);
 Static charset_t *charset_invert(charset_t *set, int *errcode);
 #pragma GCC diagnostic push

--- a/minrx.c
+++ b/minrx.c
@@ -874,7 +874,7 @@ static void
 cset_construct(Compile *c, CSet *cs, WConv_Encoding enc)
 {
 	int err = CSET_SUCCESS;
-	cs->charset = charset_create(&err, enc == Byte, enc == UTF8);
+	cs->charset = charset_create(&err, MB_CUR_MAX, enc == UTF8);
 	if (!cs->charset)
 		cserr(c, err);
 }


### PR DESCRIPTION
Crucial bug fix in minrx.c.
Additions in charset that avoid compilation warnings about unused functions.