### PR TITLE
Speed up ranges when ignoring case.

### DIFF
--- a/minrx.c
+++ b/minrx.c
@@ -1080,11 +1080,9 @@ cset_parse(Compile *c, CSet *cs, minrx_regcomp_flags_t flags, WConv_Encoding enc
 			cset_set_range(c, cs, wclo, wchi);
 			if ((flags & MINRX_REG_ICASE) != 0) {
 				for (WChar wc = wclo; wc <= wchi; ++wc) {
-					WChar l, u;
-
-					l = enc == Byte ? tolower(wc) : towlower(wc);
-					u = enc == Byte ? toupper(wc) : towupper(wc);
-					// only add the char if it's outside the original range
+					// add case alternatives only if outside the original range
+					WChar l = enc == Byte ? tolower(wc) : towlower(wc);
+					WChar u = enc == Byte ? toupper(wc) : towupper(wc);
 					if (l < wclo || l > wchi)
 						cset_set(c, cs, l);
 					if (u < wclo || u > wchi)

--- a/minrx.c
+++ b/minrx.c
@@ -1080,8 +1080,15 @@ cset_parse(Compile *c, CSet *cs, minrx_regcomp_flags_t flags, WConv_Encoding enc
 			cset_set_range(c, cs, wclo, wchi);
 			if ((flags & MINRX_REG_ICASE) != 0) {
 				for (WChar wc = wclo; wc <= wchi; ++wc) {
-					cset_set(c, cs, enc == Byte ? tolower(wc) : towlower(wc));
-					cset_set(c, cs, enc == Byte ? toupper(wc) : towupper(wc));
+					WChar l, u;
+
+					l = enc == Byte ? tolower(wc) : towlower(wc);
+					u = enc == Byte ? toupper(wc) : towupper(wc);
+					// only add the char if it's outside the original range
+					if (l < wclo || l > wchi)
+						cset_set(c, cs, l);
+					if (u < wclo || u > wchi)
+						cset_set(c, cs, u);
 				}
 			}
 		}


### PR DESCRIPTION
This change helps for extreme cases like:

```sh
echo foo | gawk 'BEGIN { RS = @/[0-\u10FFFF]/ } ; {print }
```

Which someone actually complained about...  Although it would probably make a difference for even a smaller range, like of 500 or a 1000 character in the range.

The idea is that after adding the original range, while looping through the range to add the case converted characters, check to see if the converted characters are not in the original range and only if so add them.